### PR TITLE
added native sensor_msgs::PointCloud2 support without conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(laser_assembler)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS 
-tf sensor_msgs message_filters roscpp laser_geometry filters)
+tf sensor_msgs message_filters roscpp laser_geometry filters tf2_ros)
 
 find_package(catkin REQUIRED COMPONENTS 
   ${THIS_PACKAGE_ROS_DEPS} 

--- a/include/laser_assembler/base_assembler.h
+++ b/include/laser_assembler/base_assembler.h
@@ -120,6 +120,9 @@ private:
 
   //! \brief The max number of scans to store in the scan history
   unsigned int max_scans_ ;
+  
+  //! \brief The number of scans to skip continuously
+  unsigned int skip_scans_, skip_;
 
 } ;
 
@@ -131,6 +134,11 @@ BaseAssembler<T, V>::BaseAssembler(const std::string& max_size_param_name) : pri
   private_ns_.param("tf_cache_time_secs", tf_cache_time_secs, 10.0) ;
   if (tf_cache_time_secs < 0)
     ROS_ERROR("Parameter tf_cache_time_secs<0 (%f)", tf_cache_time_secs) ;
+
+  int tmp_skip_scans;
+  private_ns_.param("skip_scans", tmp_skip_scans, 0);
+  skip_scans_ = tmp_skip_scans;
+  skip_ = skip_scans_;
 
   tf_ = new tf::TransformListener(n_, ros::Duration(tf_cache_time_secs));
   ROS_INFO("TF Cache Time: %f Seconds", tf_cache_time_secs) ;
@@ -210,6 +218,17 @@ BaseAssembler<T, V>::~BaseAssembler()
 template <class T, class V>
 void BaseAssembler<T, V>::msgCallback(const boost::shared_ptr<const T>& scan_ptr)
 {
+  
+  // skip a certain number of scans
+  if(skip_scans_ > 0){
+    if(skip_ > 0){
+      skip_--;
+      return;
+    }else{
+      skip_ = skip_scans_;
+    }
+  }
+
   ROS_DEBUG("starting msgCallback");
   const T scan = *scan_ptr ;
 

--- a/include/laser_assembler/point_cloud2_base_assembler.h
+++ b/include/laser_assembler/point_cloud2_base_assembler.h
@@ -1,0 +1,464 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Robot Operating System code by the University of Osnabrück
+ *  Copyright (c) 2015, University of Osnabrück
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ *  point_cloud2_base_assembler.h
+ *
+ *  Created on: 01.07.2015
+ *   Authors: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ */
+
+#ifndef LASER_ASSEMBLER_POINT_CLOUD2_BASE_ASSEMBLER_H
+#define LASER_ASSEMBLER_POINT_CLOUD2_BASE_ASSEMBLER_H
+
+//! \author Sebastian Puetz (spuetz@uni-osnabrueck.de)
+
+#include "base_assembler.h"
+#include "sensor_msgs/PointCloud2.h"
+#include "sensor_msgs/point_field_conversion.h"
+
+// Service
+#include "laser_assembler/AssembleScans2.h"
+
+namespace laser_assembler
+{
+
+  /**
+   * \brief Maintains a history of point clouds and generates an aggregate point cloud upon request
+   */
+  template<class T>
+    class PointCloud2BaseAssembler : public BaseAssembler<T, sensor_msgs::PointCloud2>
+  {
+    public:
+      PointCloud2BaseAssembler(const std::string& max_size_param_name);
+      ~PointCloud2BaseAssembler() ;
+
+      /** \brief Returns the number of points in the current scan
+       * \param scan The scan for for which we want to know the number of points
+       * \return the number of points in scan
+       */
+      virtual unsigned int GetPointsInScan(const T& scan) = 0 ;
+
+      /** \brief Converts the current scan into a cloud in the specified fixed frame
+       *
+       * Note: Once implemented, ConvertToCloud should NOT catch TF exceptions. These exceptions are caught by
+       * BaseAssembler, and will be counted for diagnostic information
+       * \param fixed_frame_id The name of the frame in which we want cloud_out to be in
+       * \param scan_in The scan that we want to convert
+       * \param cloud_out The result of transforming scan_in into a cloud in frame fixed_frame_id
+       */
+      virtual void Convert(const std::string& fixed_frame_id, const T& scan_in, sensor_msgs::PointCloud2& cloud_out) = 0 ;
+
+    private:
+      // ROS Input/Ouptut Handling
+      ros::ServiceServer build_cloud_server2_;
+      ros::ServiceServer assemble_scans_server2_;
+
+      //! \brief Service Callback function called whenever we need to build a cloud
+      bool buildCloud2(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
+      bool assembleScans2(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
+      bool assembleScans2Organized(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
+      bool assembleScans2Unorganized(AssembleScans2::Request& req, AssembleScans2::Response& resp) ;
+
+
+      sensor_msgs::PointField* getPointFieldByName(std::vector<sensor_msgs::PointField>& fields, const std::string& name);
+
+      /** \brief Fills-up index holes in an organized point cloud
+       *
+       * \param data_count The current index of the bytebuffer of the point cloud 2, the value will be modified
+       * \param pc The output PointCloud2 object 
+       * \param index the current scan ray index which will be insertet, the value will be modified
+       * \param previous_index the previous read scan ray index
+       * \param point_step The step of one combined field in bytes in the buffer
+       * \param fields A vector of all fields
+       * \param idx_offset The byte offset of one scan ray index
+       * \param idx_datatype The type of one scan ray index 
+       */
+      inline void fillUpIndexHoles(unsigned int& data_count,
+          sensor_msgs::PointCloud2 &pc,
+          int& previous_index,
+          int index,
+          const unsigned int point_step,
+          const std::vector<sensor_msgs::PointField>& fields,
+          const unsigned int idx_offset,
+          const unsigned int idx_datatype);
+
+      /** \brief checks the equality of two scans headers
+       *
+       * \param first_scan The first scan to assemble
+       * \param current_scan The current scan to assemble
+       * \return true, if the two scans are equal
+       */
+      bool hasEqualScanHeader(sensor_msgs::PointCloud2 &first_scan, sensor_msgs::PointCloud2 &current_scan);
+
+      //! \enables the organized mode. 
+      bool organized;
+  } ;
+
+  template <class T>
+    PointCloud2BaseAssembler<T>::PointCloud2BaseAssembler(const std::string& max_size_param_name)
+    : BaseAssembler<T, sensor_msgs::PointCloud2>(max_size_param_name)
+    {
+      this->private_ns_.param("organized", organized, false);
+
+      // ***** Start Services *****
+      std::string build_cloud2_service_name = ros::names::resolve("build_cloud2");
+      std::string assemble_scans2_service_name = ros::names::resolve("assemble_scans2");
+      build_cloud_server2_    = BaseAssembler<T, sensor_msgs::PointCloud2>::n_.advertiseService("build_cloud2", &PointCloud2BaseAssembler<T>::buildCloud2,    this);
+      assemble_scans_server2_ = BaseAssembler<T, sensor_msgs::PointCloud2>::n_.advertiseService("assemble_scans2", &PointCloud2BaseAssembler<T>::assembleScans2, this); 
+    }
+
+  template <class T>
+    PointCloud2BaseAssembler<T>::~PointCloud2BaseAssembler()
+    {
+    }
+
+  template <class T>
+    bool PointCloud2BaseAssembler<T>::hasEqualScanHeader(sensor_msgs::PointCloud2 &first_scan, sensor_msgs::PointCloud2 &current_scan){
+      bool malformed = false;
+      for (unsigned int chan_ind = 0; chan_ind < first_scan.fields.size(); chan_ind++){
+        std::string field_name = first_scan.fields[chan_ind].name;
+        sensor_msgs::PointField* field = getPointFieldByName(first_scan.fields, field_name);
+
+        if (!field){
+          ROS_FATAL("field for name \"%s\", existing in the first scan, not found in the other scan!", field_name.c_str());
+          return false;
+        }
+        if (field->offset != first_scan.fields[chan_ind].offset){
+          ROS_FATAL("Field \"%s\" has not the same offset as the first scan!", field_name.c_str());
+          malformed = true;
+        }
+        if (field->datatype != first_scan.fields[chan_ind].datatype){
+          ROS_FATAL("Field \"%s\" has not the same datatype as the first scan!", field_name.c_str());
+          malformed = true;
+        }
+        if (field->count != first_scan.fields[chan_ind].count){
+          ROS_FATAL("Field \"%s\" has not the same number of elements as the first scan!", field_name.c_str());
+          malformed = true;
+        }
+      }
+      return !malformed;
+    }
+
+  template <class T>
+    bool PointCloud2BaseAssembler<T>::buildCloud2(AssembleScans2::Request& req, AssembleScans2::Response& resp)
+    {
+      ROS_WARN("Service 'build_cloud' is deprecated. Call 'assemble_scans' instead");
+      return assembleScans2(req, resp);
+    }
+
+  template <class T>
+    sensor_msgs::PointField* PointCloud2BaseAssembler<T>::getPointFieldByName(std::vector<sensor_msgs::PointField>& fields, const std::string& name){
+      for(unsigned int i=0; i<fields.size(); i++){
+        if(fields[i].name.compare(name) == 0){
+          return &fields[i];
+        }
+      }
+      return 0; 
+    }
+  template <class T>
+    void PointCloud2BaseAssembler<T>::fillUpIndexHoles(unsigned int& data_count, sensor_msgs::PointCloud2 &pc, int& previous_index, int index, const unsigned int point_step, const std::vector<sensor_msgs::PointField>& fields, const unsigned int idx_offset, const unsigned int idx_type)
+    {
+      
+      // fill up for not existing indices
+      while(previous_index + this->downsample_factor_ < index){
+        for (unsigned int chan_ind = 0; chan_ind < fields.size(); chan_ind++)
+        {
+          const sensor_msgs::PointField field = fields[chan_ind];
+          switch(field.datatype){
+            case sensor_msgs::PointField::FLOAT32 :
+              // write NaN values for float datatypes
+              sensor_msgs::writePointCloud2BufferValue<sensor_msgs::PointField::FLOAT32, float>(
+                &(pc.data[data_count+field.offset]), nanf("")) ;
+              break ;
+            case sensor_msgs::PointField::FLOAT64 :
+              // write NaN values for double datatypes
+              sensor_msgs::writePointCloud2BufferValue<sensor_msgs::PointField::FLOAT64, double>(
+                &(pc.data[data_count+field.offset]), nan("")) ;
+              break ;
+            default:
+              // write zero values for other datatypes
+              sensor_msgs::writePointCloud2BufferValue<int>(
+                &(pc.data[data_count+field.offset]), field.datatype, 0) ;
+              break;
+          }
+        }
+        previous_index += this->downsample_factor_ ;
+        // write index value
+        sensor_msgs::writePointCloud2BufferValue<unsigned int>(
+          &(pc.data[data_count+idx_offset]), idx_type, previous_index);
+        data_count+=point_step;
+      }
+    }
+
+  template <class T>
+    bool PointCloud2BaseAssembler<T>::assembleScans2Organized(AssembleScans2::Request& req, AssembleScans2::Response& resp)
+    {
+      this->scan_hist_mutex_.lock();  
+      // Determine where in our history we actually are
+      unsigned int i = 0 ;
+
+      // Find the beginning of the request. Probably should be a search
+      while ( i < BaseAssembler<T, sensor_msgs::PointCloud2>::scan_hist_.size() &&                                                    // Don't go past end of deque
+          BaseAssembler<T, sensor_msgs::PointCloud2>::scan_hist_[i].header.stamp < req.begin )                                    // Keep stepping until we've exceeded the start time
+      {
+        i++ ;
+      }
+      unsigned int start_index = i ;
+      sensor_msgs::PointCloud2& first_scan = this->scan_hist_[start_index];
+      const unsigned int point_step = first_scan.point_step;
+      const unsigned int num_fields = first_scan.fields.size();
+
+      // Find the end of the request
+
+      int max_index = -1 ;
+      int min_index = INT_MAX ;
+      int count_scans = 0;
+      const std::string index_field_name("index");
+
+      while ( i < this->scan_hist_.size() &&                              // Don't go past end of deque
+          this->scan_hist_[i].header.stamp < req.end )                // Don't go past the end-time of the request
+      {
+        sensor_msgs::PointCloud2& current_scan = this->scan_hist_[i];
+        unsigned int pts_count = this->GetPointsInScan(current_scan) ; 
+        if(pts_count>0)
+        {
+          unsigned int pts_step = current_scan.point_step ;
+          sensor_msgs::PointField* index_field = getPointFieldByName(current_scan.fields, index_field_name) ;
+          if(!index_field){
+            ROS_ERROR("No index information found in cloud! The point field \"index\" is needed to build an organized point cloud 2");
+            return false;
+          }
+          unsigned char* first_index_entry = &(current_scan.data[0+index_field->offset]) ;
+          unsigned char* last_index_entry = &(current_scan.data[(pts_count-1)*pts_step+index_field->offset]) ;
+          int first_index_value = sensor_msgs::readPointCloud2BufferValue<int>(first_index_entry, index_field->datatype) ;
+          int last_index_value = sensor_msgs::readPointCloud2BufferValue<int>(last_index_entry, index_field->datatype) ;
+          if(max_index<last_index_value)
+            max_index = last_index_value ;
+          if(min_index>first_index_value)
+            min_index = first_index_value ;
+          i += this->downsample_factor_ ;
+          count_scans++;
+        }
+      }
+
+      int index_range = max_index - min_index + 1;
+      int index_range_downsampled = (index_range+this->downsample_factor_-1)/this->downsample_factor_;
+      unsigned int past_end_index = i ;
+
+
+      if (start_index == past_end_index)
+      {
+        resp.cloud.header.frame_id = this->fixed_frame_ ;
+        resp.cloud.header.stamp = req.end ;
+        resp.cloud.data.resize (0) ;
+        resp.cloud.fields.resize (0) ;
+        resp.cloud.height = 0;
+        resp.cloud.width = 0;
+      }
+      else
+      {
+        // Note: We are assuming that channel information is consistent across multiple scans. If not, then bad things (segfaulting) will happen
+        // Allocate space for the cloud
+        resp.cloud.data.resize (count_scans*index_range_downsampled*point_step);
+        resp.cloud.fields.resize (num_fields) ;
+        resp.cloud.point_step = point_step ;
+        resp.cloud.is_bigendian = first_scan.is_bigendian;
+
+        for (i = 0; i<num_fields; i++)
+        {
+          resp.cloud.fields[i].name = first_scan.fields[i].name ;
+          resp.cloud.fields[i].offset = first_scan.fields[i].offset;
+          resp.cloud.fields[i].datatype = first_scan.fields[i].datatype;
+          resp.cloud.fields[i].count = 1;
+        }
+        resp.cloud.header.frame_id = this->fixed_frame_ ;
+
+        unsigned int cloud_count = 0 ;
+        unsigned int data_count = 0;
+        bool is_dense = true;
+
+        for (i=start_index; i<past_end_index; i+= this->downsample_factor_)
+        {
+          sensor_msgs::PointCloud2& current_scan = this->scan_hist_[i];
+
+          is_dense &= current_scan.is_dense ;
+
+          if(!hasEqualScanHeader(first_scan, current_scan)){
+            return false;
+          }
+
+          sensor_msgs::PointField* index_field = getPointFieldByName(current_scan.fields, index_field_name) ;
+          std::vector<sensor_msgs::PointField> fields = current_scan.fields;
+          int previous_index = min_index-this->downsample_factor_;
+
+          for(unsigned int j=0; j< this->GetPointsInScan(current_scan) * point_step; j+= point_step)
+          {
+            // read the next index in the cloud
+            int index = sensor_msgs::readPointCloud2BufferValue<int>(&(current_scan.data[j+index_field->offset]), index_field->datatype);
+            // if the index is smaller than the step size (downsample_factor_), skip it
+            if(index < previous_index + this->downsample_factor_){
+              continue;
+            }
+            fillUpIndexHoles(data_count, resp.cloud, previous_index, index, point_step, fields, index_field->offset, index_field->datatype);
+            if(previous_index + this->downsample_factor_ == index){
+              for(int p_idx=0; p_idx < point_step; p_idx++){
+                resp.cloud.data[data_count++] = current_scan.data[j+p_idx] ;
+              }
+              previous_index = index;
+            }
+
+          }
+          int max_index_ext = max_index + 1;
+          fillUpIndexHoles(data_count, resp.cloud, previous_index, max_index_ext, point_step, fields, index_field->offset, index_field->datatype);
+          resp.cloud.header.stamp = current_scan.header.stamp ;
+          cloud_count ++ ;
+        }
+
+        resp.cloud.height = cloud_count ;
+        resp.cloud.width = index_range_downsampled ;
+        resp.cloud.row_step = index_range_downsampled * point_step ;
+        resp.cloud.is_dense = is_dense ;
+      }
+      this->scan_hist_mutex_.unlock() ;
+
+      ROS_DEBUG("Point Cloud Results: Aggregated from index %u->%u. BufferSize: %lu. Points in cloud: %u", start_index, past_end_index, this->scan_hist_.size(), resp.cloud.height*resp.cloud.width) ;
+      return true ;
+    }
+
+  template <class T>
+    bool PointCloud2BaseAssembler<T>::assembleScans2Unorganized(AssembleScans2::Request& req, AssembleScans2::Response& resp)
+    {
+      this->scan_hist_mutex_.lock();  
+      // Determine where in our history we actually are
+      unsigned int i = 0 ;
+
+      // Find the beginning of the request. Probably should be a search
+      while ( i < BaseAssembler<T, sensor_msgs::PointCloud2>::scan_hist_.size() &&                                                    // Don't go past end of deque
+          BaseAssembler<T, sensor_msgs::PointCloud2>::scan_hist_[i].header.stamp < req.begin )                                    // Keep stepping until we've exceeded the start time
+      {
+        i++ ;
+      }
+      unsigned int start_index = i ;
+      sensor_msgs::PointCloud2& first_scan = this->scan_hist_[start_index];
+
+      unsigned int req_pts = 0 ;          // Keep a total of the points in the current request
+      // Find the end of the request
+
+      while ( i < this->scan_hist_.size() &&                              // Don't go past end of deque
+          this->scan_hist_[i].header.stamp < req.end )                // Don't go past the end-time of the request
+      {
+        sensor_msgs::PointCloud2& current_scan = this->scan_hist_[i];
+        unsigned int pts_count = this->GetPointsInScan(current_scan) ; 
+        unsigned int pts_downsampled = (pts_count+this->downsample_factor_-1)/this->downsample_factor_ ;
+        req_pts += pts_downsampled;
+        i += this->downsample_factor_ ;
+      }
+      unsigned int past_end_index = i ;
+
+      if (start_index == past_end_index)
+      {
+        resp.cloud.header.frame_id = this->fixed_frame_ ;
+        resp.cloud.header.stamp = req.end ;
+        resp.cloud.data.resize (0) ;
+        resp.cloud.fields.resize (0) ;
+        resp.cloud.height = 0;
+        resp.cloud.width = 0;
+      }
+      else
+      {
+        // Note: We are assuming that channel information is consistent across multiple scans. If not, then bad things (segfaulting) will happen
+        // Allocate space for the cloud
+        const unsigned int point_step = first_scan.point_step;
+        const unsigned int num_fields = first_scan.fields.size();
+        resp.cloud.data.resize (req_pts * point_step);
+        resp.cloud.fields.resize (num_fields) ;
+        resp.cloud.point_step = point_step ;
+        resp.cloud.is_bigendian = first_scan.is_bigendian;
+        resp.cloud.header.frame_id = this->fixed_frame_ ;
+        resp.cloud.is_dense = true;
+        resp.cloud.height = 1 ;
+        resp.cloud.width = req_pts ;
+        resp.cloud.row_step = req_pts * point_step ;
+
+        for (i = 0; i<num_fields; i++)
+        {
+          resp.cloud.fields[i].name = first_scan.fields[i].name ;
+          resp.cloud.fields[i].offset = first_scan.fields[i].offset;
+          resp.cloud.fields[i].datatype = first_scan.fields[i].datatype;
+          resp.cloud.fields[i].count = 1;
+        }
+
+        unsigned int data_count = 0;
+
+        bool is_dense = true;
+        int max_bytes = req_pts * point_step; 
+        for (i=start_index; i<past_end_index; i+= this->downsample_factor_)
+        {
+          sensor_msgs::PointCloud2& current_scan = this->scan_hist_[i];
+          if(!hasEqualScanHeader(first_scan, current_scan)){
+            return false;
+          }
+          for(unsigned int j=0; j< this->GetPointsInScan(current_scan) * point_step; j+= (this->downsample_factor_ * point_step))
+          {
+            for(unsigned int p_idx=0; p_idx < point_step; p_idx++){
+              resp.cloud.data[data_count++] = current_scan.data[j+p_idx] ;
+            }
+          }
+          resp.cloud.header.stamp = current_scan.header.stamp ;
+          resp.cloud.is_dense &= current_scan.is_dense ;
+        }
+      }
+      this->scan_hist_mutex_.unlock() ;
+
+      ROS_DEBUG("Point Cloud Results: Aggregated from index %u->%u. BufferSize: %lu. Points in cloud: %u", start_index, past_end_index, this->scan_hist_.size(), req_pts) ;
+      return true ;
+    }
+
+  template <class T>
+    bool PointCloud2BaseAssembler<T>::assembleScans2(AssembleScans2::Request& req, AssembleScans2::Response& resp)
+    {
+      if(organized){
+        return assembleScans2Organized(req, resp);
+      }else{
+        return assembleScans2Unorganized(req, resp);
+      }
+    }
+}
+
+#endif /* point_cloud2_base_assembler.h */

--- a/include/laser_assembler/point_cloud_base_assembler.h
+++ b/include/laser_assembler/point_cloud_base_assembler.h
@@ -1,0 +1,201 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Robot Operating System code by the University of Osnabrück
+ *  Copyright (c) 2015, University of Osnabrück
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ *  point_cloud_base_assembler.h
+ *
+ *  Created on: 01.07.2015
+ *   Authors: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ */
+
+#ifndef LASER_ASSEMBLER_POINT_CLOUD_BASE_ASSEMBLER_H
+#define LASER_ASSEMBLER_POINT_CLOUD_BASE_ASSEMBLER_H
+
+//! \author Sebastian Puetz
+
+#include "base_assembler.h"
+#include "sensor_msgs/PointCloud.h"
+
+// Service
+#include "laser_assembler/AssembleScans.h"
+
+namespace laser_assembler
+{
+
+/**
+ * \brief Maintains a history of point clouds and generates an aggregate point cloud upon request
+ */
+template<class T>
+class PointCloudBaseAssembler : public BaseAssembler<T, sensor_msgs::PointCloud>
+{
+public:
+  PointCloudBaseAssembler(const std::string& max_size_param_name);
+  ~PointCloudBaseAssembler() ;
+
+  /** \brief Returns the number of points in the current scan
+   * \param scan The scan for for which we want to know the number of points
+   * \return the number of points in scan
+   */
+  virtual unsigned int GetPointsInScan(const T& scan) = 0 ;
+
+  /** \brief Converts the current scan into a cloud in the specified fixed frame
+   *
+   * Note: Once implemented, ConvertToCloud should NOT catch TF exceptions. These exceptions are caught by
+   * BaseAssembler, and will be counted for diagnostic information
+   * \param fixed_frame_id The name of the frame in which we want cloud_out to be in
+   * \param scan_in The scan that we want to convert
+   * \param cloud_out The result of transforming scan_in into a cloud in frame fixed_frame_id
+   */
+  virtual void Convert(const std::string& fixed_frame_id, const T& scan_in, sensor_msgs::PointCloud& cloud_out) = 0 ;
+
+private:
+  // ROS Input/Ouptut Handling
+  ros::ServiceServer build_cloud_server_;
+  ros::ServiceServer assemble_scans_server_;
+
+  //! \brief Service Callback function called whenever we need to build a cloud
+  bool buildCloud(AssembleScans::Request& req, AssembleScans::Response& resp) ;
+  bool assembleScans(AssembleScans::Request& req, AssembleScans::Response& resp) ;
+} ;
+
+template <class T>
+PointCloudBaseAssembler<T>::PointCloudBaseAssembler(const std::string& max_size_param_name) 
+  : BaseAssembler<T, sensor_msgs::PointCloud>(max_size_param_name)
+{
+  // ***** Start Services *****
+  build_cloud_server_    = PointCloudBaseAssembler<T>::n_.advertiseService("build_cloud", &PointCloudBaseAssembler<T>::buildCloud,    this);
+  assemble_scans_server_ = PointCloudBaseAssembler<T>::n_.advertiseService("assemble_scans", &PointCloudBaseAssembler<T>::assembleScans, this);
+}
+
+template <class T>
+PointCloudBaseAssembler<T>::~PointCloudBaseAssembler()
+{
+
+}
+
+template <class T>
+bool PointCloudBaseAssembler<T>::buildCloud(AssembleScans::Request& req, AssembleScans::Response& resp)
+{
+  ROS_WARN("Service 'build_cloud' is deprecated. Call 'assemble_scans' instead");
+  return assembleScans(req, resp);
+}
+
+
+template <class T>
+bool PointCloudBaseAssembler<T>::assembleScans(AssembleScans::Request& req, AssembleScans::Response& resp)
+{
+  this->scan_hist_mutex_.lock() ;
+  // Determine where in our history we actually are
+  unsigned int i = 0 ;
+
+  // Find the beginning of the request. Probably should be a search
+  while ( i < BaseAssembler<T, sensor_msgs::PointCloud>::scan_hist_.size() &&                                                    // Don't go past end of deque
+          BaseAssembler<T, sensor_msgs::PointCloud>::scan_hist_[i].header.stamp < req.begin )                                    // Keep stepping until we've exceeded the start time
+  {
+    i++ ;
+  }
+  unsigned int start_index = i ;
+
+  unsigned int req_pts = 0 ;                                                          // Keep a total of the points in the current request
+  // Find the end of the request
+  while ( i < BaseAssembler<T,sensor_msgs::PointCloud>::scan_hist_.size() &&                                                    // Don't go past end of deque
+          BaseAssembler<T, sensor_msgs::PointCloud>::scan_hist_[i].header.stamp < req.end )                                      // Don't go past the end-time of the request
+  {
+    req_pts += (BaseAssembler<T,
+    sensor_msgs::PointCloud>::scan_hist_[i].points.size ()+BaseAssembler<T,
+    sensor_msgs::PointCloud>::downsample_factor_-1)/ BaseAssembler<T, sensor_msgs::PointCloud>::downsample_factor_ ;
+    i += BaseAssembler<T, sensor_msgs::PointCloud>::downsample_factor_ ;
+  }
+  unsigned int past_end_index = i ;
+
+  if (start_index == past_end_index)
+  {
+    resp.cloud.header.frame_id = this->fixed_frame_ ;
+    resp.cloud.header.stamp = req.end ;
+    resp.cloud.points.resize (0) ;
+    resp.cloud.channels.resize (0) ;
+  }
+  else
+  {
+    // Note: We are assuming that channel information is consistent across multiple scans. If not, then bad things (segfaulting) will happen
+    // Allocate space for the cloud
+    resp.cloud.points.resize (req_pts);
+    const unsigned int num_channels = this->scan_hist_[start_index].channels.size ();
+    resp.cloud.channels.resize (num_channels) ;
+    for (i = 0; i<num_channels; i++)
+    {
+      resp.cloud.channels[i].name = this->scan_hist_[start_index].channels[i].name ;
+      resp.cloud.channels[i].values.resize (req_pts) ;
+    }
+    //resp.cloud.header.stamp = req.end ;
+    resp.cloud.header.frame_id = this->fixed_frame_ ;
+    unsigned int cloud_count = 0 ;
+    for (i=start_index; i<past_end_index; i+= BaseAssembler<T, sensor_msgs::PointCloud>::downsample_factor_)
+    {
+
+      // Sanity check: Each channel should be the same length as the points vector
+      for (unsigned int chan_ind = 0; chan_ind < BaseAssembler<T, sensor_msgs::PointCloud>::scan_hist_[i].channels.size(); chan_ind++)
+      {
+        if (this->scan_hist_[i].points.size () != this->scan_hist_[i].channels[chan_ind].values.size())
+          ROS_FATAL("Trying to add a malformed point cloud. Cloud has %u points, but channel %u has %u elems",
+          (int)this->scan_hist_[i].points.size (), chan_ind, (int)this->scan_hist_[i].channels[chan_ind].values.size ());
+      }
+
+      for(unsigned int j=0; j<this->scan_hist_[i].points.size (); j+=this->downsample_factor_)
+      {
+        resp.cloud.points[cloud_count].x = this->scan_hist_[i].points[j].x ;
+        resp.cloud.points[cloud_count].y = this->scan_hist_[i].points[j].y ;
+        resp.cloud.points[cloud_count].z = this->scan_hist_[i].points[j].z ;
+
+        for (unsigned int k=0; k<num_channels; k++)
+          resp.cloud.channels[k].values[cloud_count] = this->scan_hist_[i].channels[k].values[j] ;
+
+        cloud_count++ ;
+      }
+      resp.cloud.header.stamp = this->scan_hist_[i].header.stamp;
+    }
+  }
+  this->scan_hist_mutex_.unlock() ;
+
+  ROS_DEBUG("Point Cloud Results: Aggregated from index %u->%u. BufferSize: %lu. Points in cloud: %u", start_index, past_end_index, this->scan_hist_.size(), (int)resp.cloud.points.size ()) ;
+  return true ;
+}
+
+}
+
+#endif /* point_cloud_base_assembler */

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,9 @@
   <build_depend>filters</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>pluginlib</build_depend>
-  
+  <build_depend>tf2_ros</build_depend> 
+  <build_depend>tf2_sensor_msgs</build_depend> 
+ 
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>message_filters</run_depend>
@@ -33,6 +35,8 @@
   <run_depend>filters</run_depend>
   <run_depend>laser_geometry</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_sensor_msgs</run_depend>
 
   <export>
   </export>

--- a/src/laser_scan_assembler.cpp
+++ b/src/laser_scan_assembler.cpp
@@ -35,7 +35,7 @@
 
 #include "laser_geometry/laser_geometry.h"
 #include "sensor_msgs/LaserScan.h"
-#include "laser_assembler/base_assembler.h"
+#include "laser_assembler/point_cloud_base_assembler.h"
 #include "filters/filter_chain.h"
 
 using namespace laser_geometry;
@@ -47,10 +47,10 @@ namespace laser_assembler
 /**
  * \brief Maintains a history of laser scans and generates a point cloud upon request
  */
-class LaserScanAssembler : public BaseAssembler<sensor_msgs::LaserScan>
+class LaserScanAssembler : public PointCloudBaseAssembler<sensor_msgs::LaserScan>
 {
 public:
-  LaserScanAssembler() : BaseAssembler<sensor_msgs::LaserScan>("max_scans"), filter_chain_("sensor_msgs::LaserScan")
+  LaserScanAssembler() : PointCloudBaseAssembler<sensor_msgs::LaserScan>("max_scans"), filter_chain_("sensor_msgs::LaserScan")
   {
     // ***** Set Laser Projection Method *****
     private_ns_.param("ignore_laser_skew", ignore_laser_skew_, true);
@@ -78,7 +78,7 @@ public:
     return (scan.ranges.size ());
   }
 
-  void ConvertToCloud(const string& fixed_frame_id, const sensor_msgs::LaserScan& scan_in, sensor_msgs::PointCloud& cloud_out)
+  void Convert(const string& fixed_frame_id, const sensor_msgs::LaserScan& scan_in, sensor_msgs::PointCloud& cloud_out)
   {
     // apply filters on laser scan
     filter_chain_.update (scan_in, scan_filtered_);
@@ -88,7 +88,7 @@ public:
     {
       projector_.projectLaser(scan_filtered_, cloud_out);
       if (cloud_out.header.frame_id != fixed_frame_id)
-        tf_->transformPointCloud(fixed_frame_id, cloud_out, cloud_out);
+        this->tf_->transformPointCloud(fixed_frame_id, cloud_out, cloud_out);
     }
     else                     // Do it the slower (more accurate) way
     {

--- a/src/point_cloud2_assembler.cpp
+++ b/src/point_cloud2_assembler.cpp
@@ -1,40 +1,53 @@
-/*********************************************************************
-* Software License Agreement (BSD License)
-*
-*  Copyright (c) 2008, Willow Garage, Inc.
-*  All rights reserved.
-*
-*  Redistribution and use in source and binary forms, with or without
-*  modification, are permitted provided that the following conditions
-*  are met:
-*
-*   * Redistributions of source code must retain the above copyright
-*     notice, this list of conditions and the following disclaimer.
-*   * Redistributions in binary form must reproduce the above
-*     copyright notice, this list of conditions and the following
-*     disclaimer in the documentation and/or other materials provided
-*     with the distribution.
-*   * Neither the name of the Willow Garage nor the names of its
-*     contributors may be used to endorse or promote products derived
-*     from this software without specific prior written permission.
-*
-*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-*  POSSIBILITY OF SUCH DAMAGE.
-*********************************************************************/
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Robot Operating System code by the University of Osnabrück
+ *  Copyright (c) 2015, University of Osnabrück
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above 
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ *  point_cloud2_assembler.cpp
+ *
+ *  Created on: 01.07.2015
+ *   Authors: Sebastian Pütz <spuetz@uni-osnabrueck.de>
+ */
 
 
-#include "laser_assembler/base_assembler.h"
-#include <sensor_msgs/point_cloud_conversion.h>
+#include "laser_assembler/point_cloud2_base_assembler.h"
+#include <tf/transform_datatypes.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+
 
 using namespace std ;
 
@@ -47,12 +60,11 @@ namespace laser_assembler
  * params
  *  * (Several params are inherited from BaseAssemblerSrv)
  */
-class PointCloud2Assembler : public BaseAssembler<sensor_msgs::PointCloud2>
+class PointCloud2Assembler : public PointCloud2BaseAssembler<sensor_msgs::PointCloud2>
 {
 public:
-  PointCloud2Assembler() : BaseAssembler<sensor_msgs::PointCloud2>("max_clouds")
+  PointCloud2Assembler() : PointCloud2BaseAssembler<sensor_msgs::PointCloud2>("max_clouds")
   {
-
   }
 
   ~PointCloud2Assembler()
@@ -65,12 +77,24 @@ public:
     return (scan.width * scan.height);
   }
 
-  void ConvertToCloud(const string& fixed_frame_id, const sensor_msgs::PointCloud2& scan_in, sensor_msgs::PointCloud& cloud_out)
+  void Convert(const string& fixed_frame_id, const
+    sensor_msgs::PointCloud2& cloud_in, sensor_msgs::PointCloud2& cloud_out)
   {
-    sensor_msgs::PointCloud cloud_in;
-    sensor_msgs::convertPointCloud2ToPointCloud(scan_in, cloud_in);
-    tf_->transformPointCloud(fixed_frame_id, cloud_in, cloud_out) ;
-    return ;
+
+    std::string error_msg;
+    bool success = this->tf_->waitForTransform(fixed_frame_id, cloud_in.header.frame_id, cloud_in.header.stamp,
+        ros::Duration(0.1), ros::Duration(0.01), &error_msg);
+    if (!success)
+    {
+      ROS_WARN("Could not get transform! %s", error_msg.c_str());
+      return;
+    }
+
+    tf::StampedTransform transform;
+    this->tf_->lookupTransform(fixed_frame_id, cloud_in.header.frame_id,  cloud_in.header.stamp, transform);
+    geometry_msgs::TransformStamped tf_msg;
+    tf::transformStampedTFToMsg(transform, tf_msg);
+    tf2::doTransform(cloud_in, cloud_out, tf_msg);
   }
 
 private:

--- a/src/point_cloud_assembler.cpp
+++ b/src/point_cloud_assembler.cpp
@@ -33,7 +33,7 @@
 *********************************************************************/
 
 
-#include "laser_assembler/base_assembler.h"
+#include "laser_assembler/point_cloud_base_assembler.h"
 
 
 using namespace std ;
@@ -47,10 +47,10 @@ namespace laser_assembler
  * params
  *  * (Several params are inherited from BaseAssemblerSrv)
  */
-class PointCloudAssembler : public BaseAssembler<sensor_msgs::PointCloud>
+class PointCloudAssembler : public PointCloudBaseAssembler<sensor_msgs::PointCloud>
 {
 public:
-  PointCloudAssembler() : BaseAssembler<sensor_msgs::PointCloud>("max_clouds")
+  PointCloudAssembler() : PointCloudBaseAssembler<sensor_msgs::PointCloud>("max_clouds")
   {
 
   }
@@ -65,7 +65,7 @@ public:
     return (scan.points.size ());
   }
 
-  void ConvertToCloud(const string& fixed_frame_id, const sensor_msgs::PointCloud& scan_in, sensor_msgs::PointCloud& cloud_out)
+  void Convert(const string& fixed_frame_id, const sensor_msgs::PointCloud& scan_in, sensor_msgs::PointCloud& cloud_out)
   {
     tf_->transformPointCloud(fixed_frame_id, scan_in, cloud_out) ;
     return ;


### PR DESCRIPTION
Since the conversion from PointCloud2 to PointCloud and back for assembling the clouds is bad, I added a native sensor_msgs::PointCloud2 support without conversion. I also added an organized mode, to assemble PointClouds2 to an organized PointCloud2.
