### PR TITLE
[Windows][hydro] Use ${GTEST_LIBRARIES} for more portable gtest library linkage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(dummy_scan_producer ${PROJECT_NAME}_gencpp)
 
   add_executable(test_assembler test/test_assembler.cpp)
-  target_link_libraries(test_assembler ${catkin_LIBRARIES} ${Boost_LIBRARIES} gtest)
+  target_link_libraries(test_assembler ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${GTEST_LIBRARIES})
   add_dependencies(test_assembler ${PROJECT_NAME}_gencpp)
 
   add_rostest(test/test_laser_assembler.launch)


### PR DESCRIPTION
This problems manifest for the environment where "gtest" is not an exported target. I am copying the implementation here to make it more portable.

https://github.com/ros-perception/image_common/blob/hydro-devel/camera_info_manager/CMakeLists.txt#L28-L37